### PR TITLE
Fix reused cells for thumbnail assets

### DIFF
--- a/OHQBImagePicker/QBAssetsViewController.m
+++ b/OHQBImagePicker/QBAssetsViewController.m
@@ -393,7 +393,9 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
 								contentMode:PHImageContentModeAspectFill
 									options:nil
 							  resultHandler:^(UIImage *result, NSDictionary *info) {
-								  cell.imageView.image = result;
+								  if (cell.tag == indexPath.row) {
+									  cell.imageView.image = result;
+								  }
 							  }];
 }
 


### PR DESCRIPTION
Cells in the assets view controller gets reused and the possibly asynchronous requestImageForAsset can be called incorrectly. This ends up showing incorrect thumbnails in some cases.

The fix is similar to the code in the albums view controller, even though I would prefer to follow NSHipster recommendations and store in the tag the result of the requestImageForAsset instead, so that you can cancel requests and avoid extra work.
